### PR TITLE
Add OctoAcme project-management README in docs (links #2)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# OctoAcme Project Management Overview
+
+This folder contains OctoAcme's project management guidance and artifacts. The project's approach is lightweight, outcome-focused, and blends agile practices with clear governance.
+
+Summary of core processes
+
+- **Project Initiation:** Define goals, stakeholders, success criteria, and a brief project charter to align expectations early.
+- **Project Planning:** Create a roadmap and prioritized backlog, estimate work, and identify milestones and deliverables.
+- **Execution & Tracking:** Run short iterations (or feature-focused cycles), hold regular check-ins, track progress with clear metrics, and maintain status updates.
+- **Release & Deployment:** Use CI/CD pipelines, feature flags, and defined release gates with rollback plans to ensure safe deployments.
+- **Retrospective & Continuous Improvement:** Hold regular retrospectives, capture action items, and track improvements via small, measurable experiments.
+- **Risk & Communication:** Maintain a risk register, define escalation paths, and run stakeholder communications on a consistent cadence.
+- **Roles & Personas:** Clarify responsibilities (product owner, project manager, tech lead, engineers, QA, and operations) to reduce handoff friction.
+
+For details and templates, see the individual documents in this folder.


### PR DESCRIPTION
Adds docs/README.md summarizing OctoAcme processes. Links #2.